### PR TITLE
Throw 422 error when the request body is invalid

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -1,11 +1,11 @@
 'use strict';
 
 const Koa = require('koa');
-const bodyParser = require('koa-bodyparser');
 const cors = require('@koa/cors');
 const logging = require('@kasa/koa-logging');
 const requestId = require('@kasa/koa-request-id');
 const apmMiddleware = require('./middlewares/apm');
+const bodyParser = require('./middlewares/body-parser');
 const errorHandler = require('./middlewares/error-handler');
 const logger = require('./logger');
 const router = require('./routes');
@@ -29,18 +29,17 @@ class App extends Koa {
   _configureMiddlewares() {
     this.use(errorHandler());
     this.use(apmMiddleware());
-    this.use(
-      bodyParser({
-        enableTypes: ['json', 'form'],
-        formLimit: '10mb',
-        jsonLimit: '10mb'
-      })
-    );
     this.use(requestId());
     this.use(logging({
       logger,
       overrideSerializers: false
     }));
+    this.use(
+      bodyParser({
+        enableTypes: ['json'],
+        jsonLimit: '10mb'
+      })
+    );
     this.use(
       cors({
         origin: '*',

--- a/app/constants/error.js
+++ b/app/constants/error.js
@@ -21,8 +21,14 @@ module.exports.UNKNOWN_RESOURCE = {
   message: 'The specified resource was not found.'
 };
 
+module.exports.INVALID_REQUEST_BODY_FORMAT = {
+  statusCode: 422,
+  code: 'INVALID_REQUEST_BODY_FORMAT',
+  message: 'The request body has invalid format.'
+};
+
 module.exports.INVALID_REQUEST = {
-  statusCode: 423,
+  statusCode: 422,
   code: 'INVALID_REQUEST',
   message: 'The request has invalid parameters.'
 };

--- a/app/errors/application-error.js
+++ b/app/errors/application-error.js
@@ -1,0 +1,13 @@
+'use strict';
+
+/**
+ * The Base Error all Application Errors inherit from.
+ */
+class ApplicationError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'ApplicationError';
+  }
+}
+
+module.exports = ApplicationError;

--- a/app/errors/client-failure/index.js
+++ b/app/errors/client-failure/index.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const ApplicationError = require('../application-error');
+
+
+/**
+ * Thrown when the client send an invalid request.
+ */
+class ClientFailure extends ApplicationError {
+  constructor(message) {
+    super(message);
+    this.name = 'ClientFailure';
+  }
+}
+
+module.exports = ClientFailure;

--- a/app/errors/client-failure/invalid-request-body-format.js
+++ b/app/errors/client-failure/invalid-request-body-format.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const ClientFailure = require('./');
+
+
+/**
+ * Thrown when the request body has an invalid format.
+ */
+class InvalidRequestBodyFormat extends ClientFailure {
+  constructor(message) {
+    super(message);
+    this.name = 'InvalidRequestBodyFormat';
+  }
+}
+
+module.exports = InvalidRequestBodyFormat;

--- a/app/errors/client-failure/unknown-resource-error.js
+++ b/app/errors/client-failure/unknown-resource-error.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const ClientFailure = require('./');
+
+
+/**
+ * Thrown when a requested resource does not exist.
+ */
+class UnknownResourceError extends ClientFailure {
+  constructor(message) {
+    super(message);
+    this.name = 'UnknownResourceError';
+  }
+}
+
+module.exports = UnknownResourceError;

--- a/app/errors/index.js
+++ b/app/errors/index.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const ApplicationError = require('./application-error');
+const ClientFailure = require('./client-failure');
+const UnknownResourceError = require('./client-failure/unknown-resource-error');
+const InvalidRequestBodyFormat = require('./client-failure/invalid-request-body-format');
+
+
+module.exports = {
+  ApplicationError,
+  ClientFailure,
+  UnknownResourceError,
+  InvalidRequestBodyFormat,
+};

--- a/app/middlewares/body-parser.js
+++ b/app/middlewares/body-parser.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const debug = require('debug')('koa:bodyparser');
+const bodyParser = require('koa-bodyparser');
+const { InvalidRequestBodyFormat } = require('../errors');
+
+
+/**
+ * Return middleware that parses HTTP request body.
+ *
+ * @param {Object} [options={}] - Optional configuration.
+ * @return {function} Koa middleware.
+ * @throws {InvalidRequestBodyFormat} When failed to parse the request body.
+ */
+module.exports = (options = {}) => {
+  debug('Create a middleware');
+
+  return bodyParser({
+    ...options,
+    onerror: () => {
+      throw new InvalidRequestBodyFormat('Invalid format is detected in the request body');
+    }
+  });
+};

--- a/app/middlewares/error-handler.js
+++ b/app/middlewares/error-handler.js
@@ -2,7 +2,10 @@
 
 const debug = require('debug')('koa:error-handler');
 const Response = require('../utils/response');
-const { UNKNOWN_ENDPOINT, UNKNOWN_ERROR } = require('../constants/error');
+const { InvalidRequestBodyFormat } = require('../errors');
+const {
+  UNKNOWN_ENDPOINT, INVALID_REQUEST_BODY_FORMAT, UNKNOWN_ERROR
+} = require('../constants/error');
 
 
 /**
@@ -26,6 +29,9 @@ module.exports = () => {
     } catch (err) {
       debug('An error occured: %s', err.name);
 
+      if (err instanceof InvalidRequestBodyFormat) {
+        return Response.unprocessableEntity(ctx, INVALID_REQUEST_BODY_FORMAT);
+      }
       return Response.internalServerError(ctx, UNKNOWN_ERROR);
     }
   };

--- a/test/integration/error.test.js
+++ b/test/integration/error.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const supertest = require('supertest');
+const app = require('../../app');
+
+
+const server = app.listen();
+
+afterAll(async () => {
+  await app.terminate();
+});
+
+describe('Error', () => {
+  const request = supertest(server);
+
+  describe('UNKNOWN_ENDPOINT', () => {
+    it('<404> should reject the request with no-exist API endpoint', async () => {
+      const testCases = [
+        '/unknown',
+        '/api/what',
+        '/api/41-2929',
+        '/a/../api/../412929/kasa',
+      ];
+
+      for (const path  of testCases) {
+        const res = await request
+          .get(path)
+          .expect('Content-Type', /json/)
+          .expect(404);
+
+        const { status, code, data, message } = res.body;
+        expect(status).toBe('fail');
+        expect(code).toBe('UNKNOWN_ENDPOINT');
+        expect(data).toBeNull();
+        expect(message).toBe('The requested endpoint does not exist.');
+      }
+    });
+  });
+
+  describe('INVALID_REQUEST_BODY_FORMAT', () => {
+    it('<422> should reject the request body with invalid JOSN format', async () => {
+      const testCases = [
+        ['/', 'a[]'],
+        ['/users', '{[}]'],
+        ['/users/me', '1+1'],
+      ];
+
+      for (const [path, body] of testCases) {
+        const res = await request
+          .post(path)
+          .set('Content-Type', 'application/json')
+          .send(body)
+          .expect('Content-Type', /json/)
+          .expect(422);
+
+        const { status, code, data, message } = res.body;
+        expect(status).toBe('fail');
+        expect(code).toBe('INVALID_REQUEST_BODY_FORMAT');
+        expect(data).toBeNull();
+        expect(message).toBe('The request body has invalid format.');
+      }
+    });
+  });
+});


### PR DESCRIPTION
Close #44 

### Background

- No handler when the request body is invalid. For example, invalid JSON body with `Content-Type: application/json` http header.


### Problem Solving

- `koa-bodyparser` doesn't throw their own custom error, but support the custom error handler option.
  - Wrap `koa-bodyparser` with our own middleware with `onerror` option.
- No log for the bodyparser error because `bodyparser` middleware is behind of `logging` middleware.
  - Place `bodyparser` middleware into the front of `logging` middleware.


#### Trivial

- Stop to support `Content-Type: application/x-www-form-urlencoded`.
  - Most popular `http` client libraries support JSON request well.
  - Multi-part form data only supports `string` type.


### Checklist

- [x] Add custom errors and update `error-handler` middleware to catch custom errors
- [x] Wrap the `body-parser` middleware with the custom middleware
- [x] Write test cases of the invalid request body error in Integration Test
